### PR TITLE
Fix: Add missing loadTasks function to restore task persistence

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -67,6 +67,16 @@ export default function App() {
 		saveTasks([...clonedTasks]);
 	}
 
+	function loadTasks() {
+		let loadedTasks = localStorage.getItem('tasks');
+
+		let tasks = JSON.parse(loadedTasks);
+
+		if (tasks) {
+			setTasks(tasks);
+		}
+	}
+
 	function saveTasks(tasks) {
 		localStorage.setItem('tasks', JSON.stringify(tasks));
 	}


### PR DESCRIPTION
This PR adds the previously missing `loadTasks` function to ensure tasks are loaded from localStorage when the app initializes.

Changes:
- Added `loadTasks()` to read and set saved tasks
- Ensured the `useEffect()` hook can properly call it
- Fixed the issue where tasks were not persisting between reloads

Fixes #3 
